### PR TITLE
Feature Strategy Context Info

### DIFF
--- a/src/modules/strategy/dict/indicator_period.js
+++ b/src/modules/strategy/dict/indicator_period.js
@@ -15,6 +15,14 @@ module.exports = class IndicatorPeriod {
 
     return this.strategyContext.lastSignal;
   }
+  
+    
+  // Context return for the current strategy, usable to get the previous strategy signals and current positions.
+  // Usable in a strategy by calling indicatorPeriod.getStrategyContext() --> then you can use the result to grab the 
+  // current entry, last signal, etc..
+  getStrategyContext() {
+    return this.strategyContext;
+  }
 
   getIndicator(key) {
     for (const k in this.indicators) {


### PR DESCRIPTION
Added a simple method to allow a strategy to use the current strategyContext within it's logic. This method can be called with the 'period' function in your strategy enabling contextual awareness in the strategy.

With this small change, your custom strategies can now use the following information within it's code:
* Entry price (In fiat)
* Entry amount (in crypto)
* Last Signal of the strategy

For example, in a custom strategy, in the period function:

```js
// ...
period(indicatorPeriod){
    return this.strategy(
        indicatorPeriod.getPrice(),
        indicatorPeriod.getIndicator('sma200'),
        indicatorPeriod.getStrategyContext()
    );
}

// Actual Strategy
async strategy(price, sma200, context){
    // Get 
    const strategyAmount = strategyContext.amount || 0;
    const lastSignal = strategyContext.lastSignal || 'close';
    const entry = strategyContext.entry || 0;

    // Act on previous strategy
    if (lastSignal === 'long') {
        // Previously Long signal (maybe close next?)
    }
    else if (lastSignal === 'close') {
        // Previously closed, maybe short, or long
    } else if (lastSignal === 'short') {
        // Last was short, maybe close?
    }
}

```